### PR TITLE
Record sample when concatenating FASTQs locally

### DIFF
--- a/outward_assembly/io_helpers.py
+++ b/outward_assembly/io_helpers.py
@@ -156,8 +156,8 @@ def get_s3_paths_by_priority(input_csv: str, priority: int) -> list[str]:
 
 def concat_and_tag_fastq(input_files: list[PathLike], output_file: PathLike) -> None:
     """
-    Concatenates a list of input FASTQ into a combined FASTQ,
-    appending the input filename (with _{1/2}.fastq trimmed) to header lines.
+    Concatenates a list of input FASTQ into a combined FASTQ, appending the input file
+    basename (with _{1/2}.fastq trimmed) to header lines.
 
     Note: trimmed filenames are added to every fourth line;
     i.e. all records must be exactly four lines long.

--- a/outward_assembly/io_helpers.py
+++ b/outward_assembly/io_helpers.py
@@ -154,10 +154,13 @@ def get_s3_paths_by_priority(input_csv: str, priority: int) -> list[str]:
     return filtered_paths
 
 
-def concat_and_tag_fastq(input_files: list[str], output_file: str) -> None:
+def concat_and_tag_fastq(input_files: list[PathLike], output_file: PathLike) -> None:
     """
-    Concatenates a list of input fastq into a combined fastq,
+    Concatenates a list of input FASTQ into a combined FASTQ,
     appending the input filename (with _{1/2}.fastq trimmed) to header lines.
+
+    Note: trimmed filenames are added to every fourth line;
+    i.e. all records must be exactly four lines long.
 
     Args:
         input_files: A list of paths to the input files.

--- a/outward_assembly/pipeline_steps.py
+++ b/outward_assembly/pipeline_steps.py
@@ -346,6 +346,8 @@ def _subset_split_files_local(
             workdir / f"{rec.filename}_{read_num}.fastq" for rec in s3_records
         ]
         concat_and_tag_fastq(split_files, output_path)
+        for split_file in split_files:
+            (workdir / split_file).unlink()
 
     cmd_file.unlink()
 

--- a/outward_assembly/pipeline_steps.py
+++ b/outward_assembly/pipeline_steps.py
@@ -4,11 +4,12 @@ import textwrap
 from multiprocessing import cpu_count
 from pathlib import Path
 from typing import List, NamedTuple, Optional
+
 from Bio import SeqIO
 from Bio.Seq import Seq
 
 from .basic_seq_operations import is_subseq
-from .io_helpers import PathLike, S3Files
+from .io_helpers import PathLike, S3Files, concat_and_tag_fastq
 from .overlap_graph import overlap_inds
 
 # File names used across functions
@@ -344,13 +345,7 @@ def _subset_split_files_local(
         split_files = [
             workdir / f"{rec.filename}_{read_num}.fastq" for rec in s3_records
         ]
-
-        with open(output_path, "wb") as out:
-            for split_file in split_files:
-                split_path = workdir / split_file
-                with open(split_path, "rb") as f:
-                    shutil.copyfileobj(f, out)
-                split_path.unlink()
+        concat_and_tag_fastq(split_files, output_path)
 
     cmd_file.unlink()
 

--- a/tests/test_io_helpers.py
+++ b/tests/test_io_helpers.py
@@ -1,6 +1,4 @@
 import pytest
-import tempfile
-import os
 
 from outward_assembly.io_helpers import (
     process_s3_paths,
@@ -48,58 +46,55 @@ def test_count_lines(temp_empty_file):
 
 @pytest.mark.fast
 @pytest.mark.unit
-def test_concat_and_tag_fastq_forward_reads():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        sample1_fwd = os.path.join(temp_dir, "sample1_1.fastq")
-        sample2_fwd = os.path.join(temp_dir, "sample2_1.fastq")
-        output_fwd = os.path.join(temp_dir, "combined_1.fastq")
+def test_concat_and_tag_fastq_forward_reads(temp_workdir):
+    sample1_fwd = temp_workdir / "sample1_1.fastq"
+    sample2_fwd = temp_workdir / "sample2_1.fastq"
+    output_fwd = temp_workdir / "combined_1.fastq"
 
-        # Create test forward read files
-        with open(sample1_fwd, "w") as f:
-            f.write("@read1\nACGT\n+\nIIII\n@read2\nTGCA\n+\nIIII\n")
+    # Create test forward read files
+    with open(sample1_fwd, "w") as f:
+        f.write("@read1\nACGT\n+\nIIII\n@read2\nTGCA\n+\nIIII\n")
 
-        with open(sample2_fwd, "w") as f:
-            f.write("@read3\nGGGG\n+\nIIII\n")
+    with open(sample2_fwd, "w") as f:
+        f.write("@read3\nGGGG\n+\nIIII\n")
 
-        concat_and_tag_fastq([sample1_fwd, sample2_fwd], output_fwd)
+    concat_and_tag_fastq([sample1_fwd, sample2_fwd], output_fwd)
 
-        with open(output_fwd, "r") as f:
-            content = f.read()
+    with open(output_fwd, "r") as f:
+        content = f.read()
 
-        expected = "@read1 sample1\nACGT\n+\nIIII\n@read2 sample1\nTGCA\n+\nIIII\n@read3 sample2\nGGGG\n+\nIIII\n"
-        assert content == expected
-
-
-@pytest.mark.fast
-@pytest.mark.unit
-def test_concat_and_tag_fastq_empty_file():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        empty_fwd = os.path.join(temp_dir, "empty_1.fastq")
-        sample_fwd = os.path.join(temp_dir, "sample_1.fastq")
-        output_fwd = os.path.join(temp_dir, "combined_1.fastq")
-
-        # Create empty and non-empty files
-        with open(empty_fwd, "w") as f:
-            pass  # Empty file
-
-        with open(sample_fwd, "w") as f:
-            f.write("@read1\nACGT\n+\nIIII\n")
-
-        concat_and_tag_fastq([empty_fwd, sample_fwd], output_fwd)
-
-        with open(output_fwd, "r") as f:
-            content = f.read()
-
-        expected = "@read1 sample\nACGT\n+\nIIII\n"
-        assert content == expected
+    expected = "@read1 sample1\nACGT\n+\nIIII\n@read2 sample1\nTGCA\n+\nIIII\n@read3 sample2\nGGGG\n+\nIIII\n"
+    assert content == expected
 
 
 @pytest.mark.fast
 @pytest.mark.unit
-def test_concat_and_tag_fastq_file_not_found():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        nonexistent_fwd = os.path.join(temp_dir, "nonexistent_1.fastq")
-        output_fwd = os.path.join(temp_dir, "combined_1.fastq")
+def test_concat_and_tag_fastq_empty_file(temp_workdir):
+    empty_fwd = temp_workdir / "empty_1.fastq"
+    sample_fwd = temp_workdir / "sample_1.fastq"
+    output_fwd = temp_workdir / "combined_1.fastq"
 
-        with pytest.raises(RuntimeError, match="Error processing files"):
-            concat_and_tag_fastq([nonexistent_fwd], output_fwd)
+    # Create empty and non-empty files
+    with open(empty_fwd, "w") as f:
+        pass  # Empty file
+
+    with open(sample_fwd, "w") as f:
+        f.write("@read1\nACGT\n+\nIIII\n")
+
+    concat_and_tag_fastq([empty_fwd, sample_fwd], output_fwd)
+
+    with open(output_fwd, "r") as f:
+        content = f.read()
+
+    expected = "@read1 sample\nACGT\n+\nIIII\n"
+    assert content == expected
+
+
+@pytest.mark.fast
+@pytest.mark.unit
+def test_concat_and_tag_fastq_file_not_found(temp_workdir):
+    nonexistent_fwd = temp_workdir / "nonexistent_1.fastq"
+    output_fwd = temp_workdir / "combined_1.fastq"
+
+    with pytest.raises(RuntimeError, match="Error processing files"):
+        concat_and_tag_fastq([nonexistent_fwd], output_fwd)

--- a/tests/test_io_helpers.py
+++ b/tests/test_io_helpers.py
@@ -98,3 +98,15 @@ def test_concat_and_tag_fastq_file_not_found(temp_workdir):
 
     with pytest.raises(RuntimeError, match="Error processing files"):
         concat_and_tag_fastq([nonexistent_fwd], output_fwd)
+
+
+@pytest.mark.fast
+@pytest.mark.unit
+def test_concat_and_tag_fastq_bad_line_count(temp_workdir):
+    # 3 line input file can't be a legal fastq
+    infile = temp_workdir / "sample_1.fastq"
+    outfile = temp_workdir / "out.fastq"
+    with open(infile, "w") as f:
+        f.write("Chocolate\nVanilla\nStrawberry\n")
+    with pytest.raises(ValueError):
+        concat_and_tag_fastq([infile], outfile)


### PR DESCRIPTION
When concatenating forward and reverse read files output by BBDuk, tag records with the basename of the SIZ file they were found in, which is the best proxy for sample that we have. Only applies to local search; Batch version already did this.