### PR TITLE
add localtest profile for Nextflow; run tests with it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ non-conda-deps/**
 outward_assembly.egg-info/*
 
 .nextflow*
+.pytest-nf-work/**
 .env
 
 fastp*

--- a/nextflow/config/profiles.config
+++ b/nextflow/config/profiles.config
@@ -1,7 +1,5 @@
 // Currently universal settings
 docker.enabled = true // Enables Docker container execution
-// Wave related information: https://www.nextflow.io/docs/latest/wave.html#wave-page
-wave.enabled = true // Enables the use of Wave containers
 // AWS Batch related information: https://www.nextflow.io/docs/latest/reference/config.html#aws
 aws.client.maxConnections = 10000 // The maximum number of allowed open HTTP connections. Set it arbitrarily high so that we don't get limited to running jobs.
 aws.client.maxErrorRetry = 10 // The maximum number of retry attempts for failed retryable reques
@@ -11,11 +9,17 @@ aws.client.socketTimeout = 0 // The amount of time to wait (in milliseconds) for
 // Workflow run profiles
 profiles {
     standard { // Run on AWS Batch
+        wave.enabled = true
         fusion.enabled = true
         fusion.exportStorageCredentials = true
         process.executor = "awsbatch"
         process.errorStrategy = "retry"
         process.maxRetries = 3
+    }
+    localtest { // Local Nextflow execution for testing
+        fusion.enabled = false
+        process.executor = "local"
+        workDir = ".pytest-nf-work"
     }
 }
 

--- a/outward_assembly/pipeline_steps.py
+++ b/outward_assembly/pipeline_steps.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 import textwrap
@@ -31,6 +32,8 @@ MEGAHIT_FINAL_CONTIGS = "final.contigs.fa"
 MEGAHIT_FILTERED_CONTIGS = "contigs_filtered.fasta"
 CHOSEN_SUBITER_FLAG = "chose_this_subiter"
 LOG_FILE = "log.txt"
+
+NF_PROFILE_ENV_VAR = "NEXTFLOW_PROFILE"
 
 
 class FastaStats(NamedTuple):
@@ -455,6 +458,8 @@ def _subset_split_files_batch(
 
     # Run Nextflow with single dynamic config (which includes static configs)
     nextflow_cmd = ["nextflow", "run", str(nextflow_main), "-c", str(dynamic_config)]
+    if profile := os.environ.get(NF_PROFILE_ENV_VAR):
+        nextflow_cmd.extend(["-profile", profile])
 
     result = subprocess.run(nextflow_cmd, capture_output=True, text=True)
 

--- a/tests/integration/test_kmer_counting.py
+++ b/tests/integration/test_kmer_counting.py
@@ -1,11 +1,8 @@
 import pytest
 from Bio import SeqIO
-from dotenv import load_dotenv
 
 from outward_assembly.io_helpers import process_s3_paths
 from outward_assembly.kmer_freq_filter import _high_freq_kmers_split_files
-
-load_dotenv()
 
 
 @pytest.mark.slow

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -8,6 +8,7 @@ from Bio import SeqIO
 from dotenv import load_dotenv
 
 from outward_assembly.pipeline import outward_assembly
+from outward_assembly.pipeline_steps import NF_PROFILE_ENV_VAR
 
 load_dotenv()
 
@@ -25,7 +26,7 @@ load_dotenv()
     ],
     ids=["batch-single-seed", "local-single-seed", "local-multi-seed"],
 )
-def test_pipeline(temp_workdir, use_batch, seed_config):
+def test_pipeline(temp_workdir, use_batch, seed_config, monkeypatch):
     """End to end test of full pipeline, following a simulated genome with
     structure ABCBD -- note the repeated B -- with three combinations:
     1. Batch mode with single seed
@@ -67,6 +68,7 @@ def test_pipeline(temp_workdir, use_batch, seed_config):
         }
 
         if use_batch:
+            monkeypatch.setenv(NF_PROFILE_ENV_VAR, "localtest")
             kwargs.update(
                 {
                     "use_batch": True,

--- a/tests/integration/test_subset_reads.py
+++ b/tests/integration/test_subset_reads.py
@@ -8,6 +8,7 @@ from outward_assembly.io_helpers import _count_lines, process_s3_paths
 from outward_assembly.pipeline_steps import (
     _subset_split_files_batch,
     _subset_split_files_local,
+    NF_PROFILE_ENV_VAR,
 )
 
 load_dotenv()
@@ -19,7 +20,7 @@ load_dotenv()
 @pytest.mark.requires_tools
 @pytest.mark.requires_aws
 @pytest.mark.parametrize("use_batch", [True, False])
-def test_subset_reads(temp_workdir, use_batch):
+def test_subset_reads(temp_workdir, use_batch, monkeypatch):
     """Integration test of _subset_split_files.
     We pass in two split files with two read pairs each. The dummy contigs match the first
     forward read and last reverse read, so we should get two read pairs out.
@@ -41,6 +42,7 @@ def test_subset_reads(temp_workdir, use_batch):
     }
 
     if use_batch:
+        monkeypatch.setenv(NF_PROFILE_ENV_VAR, "localtest")
         kwargs.update(
             {
                 "batch_workdir": os.getenv("BATCH_WORKDIR"),


### PR DESCRIPTION
This adds a profile for Nextflow which uses local execution rather than AWS Batch. Running the full test suite with Batch takes 3-10 minutes; running this way takes ~56 seconds. So this seems fast enough that running the full suite in CI (to do) isn't crazy. (Still wish for much faster, of course.)

The main downsides are
* We're not testing Nextflow's Batch execution and the standard profile. Presumably we can trust our third party tool -- Nextflow -- to be correct, but a small part of our usage thereof is untested.
* Slight hackiness of checking an environment variable to add a profile to the `nextflow run` invocation.

I think it's worth it; a < 1 minute test suite is much more usable than a > 5 minute suite. But I'm open to thoughts and suggestions.