### PR TITLE
Deduplication part 1: headers and bucketing

### DIFF
--- a/outward_assembly/dedup.py
+++ b/outward_assembly/dedup.py
@@ -1,0 +1,163 @@
+"""
+Post-assembly read-pair deduplication with error-tolerant matching.
+
+This module provides deduplication of read pairs using minimizer-based
+bucket for efficiency. Deduplication is tolerant to small alignment
+shifts and sequencing errors.
+"""
+
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from itertools import combinations
+from zlib import crc32
+from typing import Dict, List, Literal, Optional, Set, Tuple
+
+import networkx as nx
+
+# No Bio import; we represent sequences as strings rather than Bio.Seq:
+# - Don't need any Bio machinery
+# - Python string operations are faster than the corresponding Seq operations
+
+ORIENT_STRICT = "strict"
+ORIENT_TOLERANT = "tolerant"
+
+
+@dataclass
+class MinimizerParams:
+    """Minimizer configuration (rarely needs changing)."""
+
+    num_windows: int = 2  # Number of windows per read
+    window_len: int = 20  # Base pairs per window
+    kmer_len: int = 7  # K-mer size for minimizers
+
+    def __post_init__(self):
+        if self.kmer_len > self.window_len:
+            raise ValueError(
+                f"kmer_len ({self.kmer_len}) must be <= window_len ({self.window_len})"
+            )
+
+
+@dataclass
+class ReadPair:
+    """Container for a read pair with deduplication support."""
+
+    read_id: str
+    fwd_seq: str
+    rev_seq: str
+    fwd_qual: str
+    rev_qual: str
+    exemplar_id: Optional[str] = field(default=None, init=False)
+
+    def __post_init__(self):
+        """Ensure sequences are uppercase."""
+        self.fwd_seq = self.fwd_seq.upper()
+        self.rev_seq = self.rev_seq.upper()
+
+    def mean_qual(self) -> float:
+        """Calculate mean Phred quality across both reads."""
+        quals = [ord(c) - 33 for c in self.fwd_qual + self.rev_qual]
+        return sum(quals) / len(quals) if quals else 0.0
+
+
+##
+# Assign read pairs to buckets based on minimizers.
+# Each read pair will be assigned to multiple buckets.
+# With high probability, duplicate read pairs will be assigned to at least
+# one bucket in common, so we only need to do all-against-all read pair comparisons
+# within each bucket.
+##
+
+# Complement table for reverse complement (including N)
+_COMPLEMENT = str.maketrans("ACGTN", "TGCAN")
+
+
+def _reverse_complement(seq: str) -> str:
+    """Return reverse complement of DNA sequence."""
+    return seq.translate(_COMPLEMENT)[::-1]
+
+
+def _canonical_kmer(kmer: str) -> str:
+    """Return lexicographically smaller of kmer and its reverse complement."""
+    rc = _reverse_complement(kmer)
+    return min(kmer, rc)
+
+def _hash_kmer(kmer: str) -> int:
+    """Hash a kmer to an int. The actual hash used is an implementation detail,
+    but the result must be stable run-to-run (so no default Python hash)."""
+    return crc32(kmer.encode())
+
+def _extract_minimizer(seq: str, window_idx: int, params: MinimizerParams) -> int:
+    """
+    Extract the minimizer hash from a specific window of the sequence.
+
+    Args:
+        seq: DNA sequence
+        window_idx: Which window to process (0-based)
+        params: Minimizer parameters
+
+    Returns:
+        Hash of the lexicographically smallest canonical k-mer in the window
+    """
+    start = window_idx * params.window_len
+    end = min(len(seq), start + params.window_len)
+
+    if end - start < params.kmer_len:
+        # Window too short to contain a k-mer - return consistent hash
+        return _hash_kmer("EMPTY")
+
+    # Find minimizer (smallest hash) in this window
+    bigger_than_hash = sys.maxsize + 1
+    min_hash = bigger_than_hash
+    for i in range(start, end - params.kmer_len + 1):
+        kmer = seq[i : i + params.kmer_len]
+        if "N" not in kmer:  # Skip k-mers with ambiguous bases
+            canonical = _canonical_kmer(kmer)
+            h = _hash_kmer(canonical)
+            if h < min_hash:
+                min_hash = h
+
+    return min_hash if min_hash != bigger_than_hash else _hash_kmer("EMPTY")
+
+
+def _get_bucket_keys(
+    read_pair: ReadPair, params: MinimizerParams, orientation: str
+) -> Set[Tuple[int, int]]:
+    """
+    Generate all bucket keys for a read pair based on minimizers.
+
+    Returns set of (forward_hash, reverse_hash) tuples that serve as bucket keys.
+    """
+    # Extract minimizers from each window
+    fwd_hashes = [
+        _extract_minimizer(read_pair.fwd_seq, i, params)
+        for i in range(params.num_windows)
+    ]
+    rev_hashes = [
+        _extract_minimizer(read_pair.rev_seq, i, params)
+        for i in range(params.num_windows)
+    ]
+
+    # Generate all hash pairs
+    keys = {(fh, rh) for fh in fwd_hashes for rh in rev_hashes}
+
+    # In tolerant mode, also consider swapped orientation
+    if orientation == ORIENT_TOLERANT:
+        keys |= {(rh, fh) for fh in fwd_hashes for rh in rev_hashes}
+
+    return keys
+
+
+def _assign_to_buckets(
+    read_pairs: List[ReadPair], minimizer_params: MinimizerParams, orientation: str
+) -> Dict[Tuple[int, int], List[int]]:
+    """Assign read pairs to buckets by minimizers. Return a Dict {bucket_key : indices}
+    where bucket_key is a tuple of ints (kmer hashes) and indices are relative to the
+    input list of read pairs."""
+    buckets = defaultdict(list)
+    for idx, rp in enumerate(read_pairs):
+        keys = _get_bucket_keys(rp, minimizer_params, orientation)
+        for key in keys:
+            buckets[key].append(idx)
+    return buckets
+

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,218 @@
+"""Unit tests for outward_assembly.dedup module."""
+
+import random
+
+import networkx as nx
+import pytest
+
+from outward_assembly.dedup import (
+    ORIENT_STRICT,
+    ORIENT_TOLERANT,
+    DedupParams,
+    MinimizerParams,
+    ReadPair,
+    _assign_to_buckets,
+    _build_graph,
+    _canonical_kmer,
+    _extract_minimizer,
+    _get_bucket_keys,
+    _hash_kmer,
+    _mismatch_count,
+    _read_pairs_equivalent,
+    _reverse_complement,
+    _select_exemplar_by_centrality,
+    _sequences_match,
+    deduplicate_read_pairs,
+)
+
+
+def _random_seq(length: int, rng: random.Random) -> str:
+    """Generate random DNA sequence of specified length."""
+    return "".join(rng.choices(["A", "C", "G", "T"], k=length))
+
+
+class TestHelperFunctions:
+    """Test sequence manipulation helper functions."""
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_reverse_complement_standard_bases(self):
+        assert _reverse_complement("ACGT") == "ACGT"
+        assert _reverse_complement("AAAA") == "TTTT"
+        assert _reverse_complement("TTTT") == "AAAA"
+        assert _reverse_complement("GCGC") == "GCGC"
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_reverse_complement_with_n(self):
+        assert _reverse_complement("ACGTN") == "NACGT"
+        assert _reverse_complement("NNNNN") == "NNNNN"
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_reverse_complement_empty(self):
+        assert _reverse_complement("") == ""
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_canonical_kmer_lexicographic_selection(self):
+        assert _canonical_kmer("AAAA") == "AAAA"  # AAAA vs TTTT
+        assert _canonical_kmer("TTTT") == "AAAA"  # Same result
+        assert _canonical_kmer("ACGT") == "ACGT"  # ACGT vs ACGT (palindrome)
+        assert _canonical_kmer("AAAC") == "AAAC"  # AAAC vs GTTT
+        assert _canonical_kmer("GTTT") == "AAAC"  # Same result
+
+
+class TestMinimizerExtraction:
+    """Test minimizer extraction functions."""
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_extract_minimizer_normal_window(self):
+        params = MinimizerParams(num_windows=2, window_len=20, kmer_len=7)
+        seq = "A" * 20 + "C" * 20  # 40bp sequence
+
+        # Test first window (all A's - should give consistent result)
+        hash1 = _extract_minimizer(seq, 0, params)
+        hash2 = _extract_minimizer(seq, 0, params)
+        assert hash1 == hash2  # Should be deterministic
+
+        # Test second window (all C's - should give different result)
+        hash3 = _extract_minimizer(seq, 1, params)
+        assert hash1 != hash3  # Different sequences should give different hashes
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_extract_minimizer_with_n_bases(self):
+        params = MinimizerParams(num_windows=1, window_len=10, kmer_len=3)
+        seq_with_n = "AANAAAANAA"
+        seq_without_n = "AAGAAAAGAA"
+
+        hash_with_n = _extract_minimizer(seq_with_n, 0, params)
+        hash_without_n = _extract_minimizer(seq_without_n, 0, params)
+
+        # Should skip N-containing kmers and find valid ones
+        assert hash_with_n != _hash_kmer("EMPTY")
+        assert hash_without_n != _hash_kmer("EMPTY")
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_extract_minimizer_window_too_short(self):
+        params = MinimizerParams(num_windows=1, window_len=10, kmer_len=7)
+        seq = "AAAAA"  # 5bp sequence, need 7bp kmer
+
+        hash_result = _extract_minimizer(seq, 0, params)
+        assert hash_result == _hash_kmer("EMPTY")
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_extract_minimizer_all_N_window(self):
+        params = MinimizerParams(num_windows=1, window_len=10, kmer_len=3)
+        seq = "NNNNNNNNNN"
+
+        hash_result = _extract_minimizer(seq, 0, params)
+        assert hash_result == _hash_kmer("EMPTY")
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_get_bucket_keys(self):
+        params = MinimizerParams(num_windows=2, window_len=20, kmer_len=7)
+        rng = random.Random("hello")
+        rp = ReadPair(
+            "test", _random_seq(40, rng), _random_seq(40, rng), "I" * 40, "I" * 40
+        )
+
+        # Strict mode should generate num_windows² keys:
+        # num_windows minimizers in the fwd seq x num_windows in the rev seq
+        keys = _get_bucket_keys(rp, params, ORIENT_STRICT)
+        assert len(keys) == 4
+        assert all(isinstance(key, tuple) and len(key) == 2 for key in keys)
+
+        # Tolerant mode should generate 2*num_windows² keys:
+        # num_windows minimizers in the fwd seq x num_windows in the rev seq,
+        # times 2 for swapping fwd/rev
+        keys = _get_bucket_keys(rp, params, ORIENT_TOLERANT)
+        assert len(keys) == 8
+        assert all(isinstance(key, tuple) and len(key) == 2 for key in keys)
+
+
+class TestBucketing:
+    """Test bucketing functions."""
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_assign_to_buckets_correct_assignment(self):
+        # Identical read pairs should go to same bucket
+        params = MinimizerParams(num_windows=1, window_len=10, kmer_len=3)
+
+        rp1 = ReadPair("read1", "A" * 10, "T" * 10, "I" * 10, "I" * 10)
+        rp2 = ReadPair("read2", "A" * 10, "T" * 10, "I" * 10, "I" * 10)
+
+        buckets = _assign_to_buckets([rp1, rp2], params, ORIENT_STRICT)
+
+        # Should have at least one bucket containing both reads
+        found_shared_bucket = False
+        for bucket_indices in buckets.values():
+            if len(bucket_indices) >= 2:
+                found_shared_bucket = True
+                break
+
+        assert found_shared_bucket is True
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_assign_to_buckets_multiple_buckets(self):
+        # Same read should appear in multiple buckets
+        params = MinimizerParams(num_windows=2, window_len=10, kmer_len=3)
+
+        rp = ReadPair("read1", "A" * 20, "T" * 20, "I" * 20, "I" * 20)
+
+        buckets = _assign_to_buckets([rp], params, ORIENT_STRICT)
+
+        # Read should appear in multiple buckets (W² = 4 buckets)
+        total_appearances = sum(1 for indices in buckets.values() if 0 in indices)
+        assert total_appearances >= 1
+
+
+class TestReadPairClass:
+    """Test ReadPair class functionality."""
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_post_init_sequences_uppercase(self):
+        rp = ReadPair("test", "acgt", "tgca", "IIII", "IIII")
+        assert rp.fwd_seq == "ACGT"
+        assert rp.rev_seq == "TGCA"
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_mean_qual_calculation(self):
+        # Phred 33: '!' = 0, 'I' = 40
+        rp = ReadPair("test", "AAAA", "TTTT", "!!!!", "IIII")
+        expected_mean = (0 + 0 + 0 + 0 + 40 + 40 + 40 + 40) / 8
+        assert rp.mean_qual() == expected_mean
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_mean_qual_empty_qualities(self):
+        rp = ReadPair("test", "AAAA", "TTTT", "", "")
+        assert rp.mean_qual() == 0.0
+
+
+class TestParameterValidation:
+    """Test parameter validation."""
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_minimizer_params_kmer_too_large(self):
+        with pytest.raises(ValueError, match="kmer_len .* must be <= window_len"):
+            MinimizerParams(window_len=5, kmer_len=7)
+
+    @pytest.mark.fast
+    @pytest.mark.unit
+    def test_minimizer_params_valid(self):
+        params = MinimizerParams(window_len=10, kmer_len=5)
+        assert params.window_len == 10
+        assert params.kmer_len == 5
+
+


### PR DESCRIPTION
Part 1 of sequence based deduplication logic. Check out [this branch](https://github.com/naobservatory/outward-assembly/tree/ef_dedup) to see where it's going.

The general plan for deduplication is:
1. Build a graph over all read pairs, where vertices are read pairs and edges indicate equivalence.
2. Connected components of this graph are clusters; pick a central exemplar from each cluster.

The problem is that step 1, naively implemented, requires `n * (n-1) / 2` equivalence checks for `n` read pairs. Instead, we use a min-hash system to bucket read pairs. A read pair may be (almost surely is) assigned to multiple buckets. All possible equivalence relationships are within-bucket, so we can check many fewer pairs of read pairs for equivalence.

To bucket a read pair, we associate both mates with `W` hashes for `W` a number of windows (default 2). Windows are non-overlapping adjacent regions (e.g. first 20bp, next 20bp). The hash associated with a window is the minimum hash of all canonical k-mers in that window.

A read pair's buckets are then `{(hF, hR) for hF in fwd_mate_hashes for hR in rev_mate_hashes}`. You'll note that a pair of true-duplicate read pairs are highly likely to have a bucket `(hF, hR)` in common; for this not to happen, the duplicates would have to differ in one of the bases forming the min-hash kmer in _every_ window of the forward mate, or likewise for the reverse mate. Given Illumina's high accuracy, this is quite rare. We're also somewhat tolerant to read offsets, where e.g. RP1 is a dup of RP2 but for some reason is offset by a base or two.

This PR just introduces and tests the bucketing logic. The next PR will follow up with equivalence between read pairs and the (really quite small) graph logic for clustering and picking exemplars.