### PR TITLE
Nextflow/Batch: collate BBDuk tasks

### DIFF
--- a/nextflow/main.nf
+++ b/nextflow/main.nf
@@ -1,37 +1,39 @@
 nextflow.preview.output = true
 
 // BBDUK filters the reads for those containing the target sequence (or k-mers of the target sequence)
-// Input: Paired-end reads (zstd compressed and interleaved), target sequence/k-mers of target seqeunce, k used for BBDuk
-// Output: Filtered forward and reverse reads that match the reference
-// Parameters:
-//   - Uses exact kmer matching (mm=f)
-//   - Maintains read order (ordered=t)
-//   - Processes both forward and reverse complement (rcomp=t)
-//   - Expects interleaved input (interleaved=t)
-//   - Requires at least 1 kmer hit (minkmerhits=1)
+// Processes multiple input files per task to reduce overhead
 process BBDUK {
-    label "medium"
-    label "BBTools"
-    input:
-        tuple val(sample_div), path(reads)
-        path(ref_fasta_path)
-        val(k)
-    output:
-        tuple val(sample_div), path("${sample_div}_{1,2}.fastq")
-    shell:
-        '''
-        # Define input/output
-        io="in=stdin.fastq ref=!{ref_fasta_path} outm=!{sample_div}_1.fastq outm2=!{sample_div}_2.fastq "
-        # Define parameters
-        par="ordered=t rcomp=t minkmerhits=1 mm=f interleaved=t k=!{k} t=!{task.cpus} -Xmx!{task.memory.toGiga()}g"
-        # Execute
-        zstdcat !{reads} | bbduk.sh ${io} ${par}
-        '''
+  label "medium"
+  label "BBTools"
+  input:
+    tuple val(sample_divs), path(reads_files)
+    path(ref_fasta_path)
+    val(k)
+  output:
+    path("*_1.fastq"), emit: fwd_reads
+    path("*_2.fastq"), emit: rev_reads
+  script:
+    """
+    # Convert space-separated lists to arrays
+    IFS=' ' read -ra samples <<< "${sample_divs.join(' ')}"
+    IFS=' ' read -ra files <<< "${reads_files.join(' ')}"
+    
+    # Process each file with its corresponding sample_div
+    for i in "\${!samples[@]}"; do
+      sample_div="\${samples[\$i]}"
+      reads_file="\${files[\$i]}"
+      
+      # Define input/output
+      io="in=stdin.fastq ref=${ref_fasta_path} outm=\${sample_div}_1.fastq outm2=\${sample_div}_2.fastq"
+      # Define parameters
+      par="ordered=t rcomp=t minkmerhits=1 mm=f interleaved=t k=${k} t=${task.cpus} -Xmx${task.memory.toGiga()}g"
+      # Execute
+      zstdcat "\${reads_file}" | bbduk.sh \${io} \${par}
+    done
+    """
 }
 
-// CONCAT_READS concatenates several forward and reverse reads into a single forward and reverse read file, adding the filename to the read id
-// Input: Several forward and reverse read files (from BBDUK process)
-// Output: Two consolidated FASTQ files (one forward, one reverse)
+// CONCAT_READS concatenates several forward and reverse reads into a single forward and reverse read file
 process CONCAT_READS{
   label "small"
   label "coreutils"
@@ -41,51 +43,59 @@ process CONCAT_READS{
   output:
     path("reads_1.fastq"), emit: final_fwd_read
     path("reads_2.fastq"), emit: final_rev_read
-  shell:
-    '''
+  script:
+    """
     # Process forward reads
-    for fwd in !{fwd_reads}; do
-      filename=$(basename "$fwd" _1.fastq)
-      awk -v fname="$filename" 'NR%4==1 {print $0 " " fname; next} {print}' "$fwd"
+    for fwd in ${fwd_reads}; do
+      filename=\$(basename "\$fwd" _1.fastq)
+      awk -v fname="\$filename" 'NR%4==1 {print \$0 " " fname; next} {print}' "\$fwd"
     done > "reads_1.fastq"
 
     # Process reverse reads
-    for rev in !{rev_reads}; do
-      filename=$(basename "$rev" _2.fastq)
-      awk -v fname="$filename" 'NR%4==1 {print $0 " " fname; next} {print}' "$rev"
+    for rev in ${rev_reads}; do
+      filename=\$(basename "\$rev" _2.fastq)
+      awk -v fname="\$filename" 'NR%4==1 {print \$0 " " fname; next} {print}' "\$rev"
     done > "reads_2.fastq"
-    '''
+    """
 }
 
 workflow {
   main:
-    reads = Channel.fromPath(params.s3_files).splitCsv(header: false, sep: "\t"). map {
-      row -> tuple(row[0], row[1])
-    }
-    bbduk_reads = BBDUK(reads, params.ref_fasta_path, params.kmer)
-
-    // Filter out empty reads
-    filtered_bbduk_reads = bbduk_reads
-      .filter { _sample_div, fastq_files -> 
-          fastq_files[0].size() > 0 && fastq_files[1].size() > 0
+    // Load input files and create channel
+    reads = Channel.fromPath(params.s3_files)
+      .splitCsv(header: false, sep: "\t")
+      .map { row -> tuple(row[0], row[1]) }
+    
+    // Batch inputs (default 10 per batch, configurable via params.batch_size)
+    batch_size = params.batch_size ?: 10
+    
+    // Batch the tuples using collate
+    batched_reads = reads
+      .collate(batch_size)
+      .map { batch ->
+        def sample_divs = batch.collect { it[0] }
+        def files = batch.collect { file(it[1]) }
+        tuple(sample_divs, files)
       }
-
-    fwd_reads = filtered_bbduk_reads
-        .toSortedList { a, b -> a[0] <=> b[0] }  // Sort by sample_div
-        .flatMap()  // Flatten the sorted list back to a channel
-        .map { _sample_div, fastq_files -> 
-            fastq_files[0]  // This selects the first FASTQ file (ending with _1.fastq)
-        }
-        .collect()
-
-    rev_reads = filtered_bbduk_reads
-        .toSortedList { a, b -> a[0] <=> b[0] }  // Sort by sample_div
-        .flatMap()  // Flatten the sorted list back to a channel
-        .map { _sample_div, fastq_files -> 
-            fastq_files[1]  // This selects the second FASTQ file (ending with _2.fastq)
-        }
-        .collect()
-
+    
+    // Process batches
+    bbduk_results = BBDUK(batched_reads, params.ref_fasta_path, params.kmer)
+    
+    // Collect and filter outputs
+    fwd_reads = bbduk_results.fwd_reads
+      .flatten()
+      .filter { it.size() > 0 }
+      .toSortedList { a, b -> 
+        a.name.tokenize('_')[0] <=> b.name.tokenize('_')[0]
+      }
+      
+    rev_reads = bbduk_results.rev_reads
+      .flatten()
+      .filter { it.size() > 0 }
+      .toSortedList { a, b ->
+        a.name.tokenize('_')[0] <=> b.name.tokenize('_')[0]
+      }
+    
     CONCAT_READS(fwd_reads, rev_reads)
 
   publish:


### PR DESCRIPTION
Have each Nextflow process run BBDuk on 10 SIZ chunks, rather than 1, to better amortize task spin-up / spin-down time. This should save around $2 in AWS compute per 25,000 SIZ files searched (ie a 25B flow cell) per iteration. It _might_ improve the wall clock time slightly as well, hard to tell since so much of the wall clock time depends on Batch queueing time and the spot market, both of which are outside our control.