### PR TITLE
Fix Nextflow assertion

### DIFF
--- a/nextflow/main.nf
+++ b/nextflow/main.nf
@@ -48,6 +48,12 @@ process CONCAT_READS{
     path("reads_2.fastq"), emit: final_rev_read
   script:
     """
+    # Check that forward and reverse read counts match
+    [ \$(echo ${fwd_reads} | wc -w) -eq \$(echo ${rev_reads} | wc -w) ] || { 
+      echo "Error: Unequal number of forward (\$(echo ${fwd_reads} | wc -w)) and reverse (\$(echo ${rev_reads} | wc -w)) read files"
+      exit 1
+    }
+    
     # Process forward reads
     for fwd in ${fwd_reads}; do
       filename=\$(basename "\$fwd" _1.fastq)
@@ -95,7 +101,6 @@ workflow {
       .toSortedList { a, b ->
         a.name.tokenize('_')[0] <=> b.name.tokenize('_')[0]
       }
-    assert fwd_reads.size() == rev_reads.size() : "Forward and reverse reads must have equal length (fwd: ${fwd_reads.size()}, rev: ${rev_reads.size()})"
     CONCAT_READS(fwd_reads, rev_reads)
 
   publish:


### PR DESCRIPTION
The last commit introduced a bad Nextflow assertion which didn't play nicely with the lazy nature of Nextflow channels. (And we should have been checking the length of list elements anyway.) This moves the assertion logic into the CONCAT_READS process.