### PR TITLE
KMC via oa-tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-non-conda-deps/**
 **__pycache__**
 **.pyc
 outward_assembly.egg-info/*

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,9 +6,7 @@ Briefly, the outward assembly software has two profiles (read our [usage docs](.
 * *Local*: Run outward assembly using your local machine.
 * *Batch*: Run outward assembly using AWS Batch (via Nextflow) for distributed read searching; other algorithm steps run locally.
 
-In the situation that you want to use the *batch* profile, you will need to follow the [instructions below to install the required software](#optional-batch-profile).
-
-Additionally, if one would like generate high frequency k-mers to use for the outward assembly software, you can follow the [instructions below to install the required software](#optional-kmc).
+If you want to use the *batch* profile, you'll also need to follow the [instructions below to install the required software](#optional-batch-profile).
 
 ## Basic requirements
 
@@ -31,7 +29,7 @@ source .venv/bin/activate  # Linux/macOS
 
 ### Bioinformatics tools
 
-Bioinformatics tools are managed via conda using the **tools-only** environment (`oa_tools_env.yml`) that contains just the bioinformatics tools (BBMap/BBDuk, MEGAHIT, fastp) without Python dependencies:
+Bioinformatics tools are managed via conda using the **tools-only** environment (`oa_tools_env.yml`) that contains just the bioinformatics tools (BBMap/BBDuk, MEGAHIT, fastp, KMC) without Python dependencies:
 
 ```bash
 mamba env create -n oa-tools -f oa_tools_env.yml --channel-priority flexible
@@ -120,6 +118,4 @@ Though each Batch job runs for just a few seconds, running outward assembly at s
 ### Seqera Tower Credentials
 Using the Batch profile requires a Seqera Tower [access token](https://docs.seqera.io/platform-cloud/api/overview). See your tokens or create a new one in the Seqera [console](https://cloud.seqera.io/tokens).
 
-## (Optional) KMC
-
-The `oa-tools` conda environment does not include the kmer counting tool KMC. Kmer counting with KMC is not required for outward assembly, but you may find it helpful to use KMC to generate a list of high frequency kmers. `kmer_freq_filter.py` contains helper functions for computing high frequency kmers using KMC and creating frequency-filtered subsets of input reads. By default, these functions look for KMC's executable at `outward-assembly/non-conda-deps/kmc3/bin`. KMC binaries are available on [GitHub](https://github.com/refresh-bio/KMC/releases). 
+ 

--- a/oa_tools_env.yml
+++ b/oa_tools_env.yml
@@ -6,4 +6,4 @@ dependencies:
   - bbmap>=39,<40
   - megahit>=1.2,<2
   - fastp>=0.24,<1
-
+  - kmc>=3.2.4,<4

--- a/oa_tools_lock.yml
+++ b/oa_tools_lock.yml
@@ -28,6 +28,7 @@ dependencies:
   - icu=75.1=he02047a_0
   - isa-l=2.31.1=hb9d3cd8_1
   - keyutils=1.6.3=hb9d3cd8_0
+  - kmc=3.2.4=haf24da9_3
   - krb5=1.21.3=h659f571_0
   - lcms2=2.17=h717163a_0
   - ld_impl_linux-64=2.44=h1423503_1

--- a/outward_assembly/kmer_freq_filter.py
+++ b/outward_assembly/kmer_freq_filter.py
@@ -9,8 +9,7 @@ from typing import Optional
 
 from .io_helpers import PathLike, S3Files
 
-# Constants
-KMC_PATH = Path(__file__).parent.parent / "non-conda-deps/kmc3/bin"
+# kmc and kmc_tools are expected to be available on PATH via the oa-tools conda environment
 
 
 def _make_kmer_count_commands(
@@ -54,13 +53,13 @@ def _make_kmer_count_commands(
             f"mkdir -p {tmp_dir} {kmc_tmp_dir} && "
             f"aws s3 cp {rec.s3_path} - | "
             f"zstd -d - -o {tmp_fastq} && "
-            f"{KMC_PATH}/kmc -k{k} "  # k-mer length
+            f"kmc -k{k} "  # k-mer length
             f"-cs{max_count} "  # max count before counter saturates
             f"-ci{min_kmer_freq} "  # min count to store k-mer
             f"-t{threads} "  # number of threads
             f"-m{memory_GB} "  # max memory usage in GB
             f"{tmp_fastq} {kmc_out_prefix} {kmc_tmp_dir} && "
-            f"{KMC_PATH}/kmc_tools transform {kmc_out_prefix} dump {high_freq_out} && "
+            f"kmc_tools transform {kmc_out_prefix} dump {high_freq_out} && "
             f"rm -rf {tmp_dir}"
         )
         commands.append(cmd)


### PR DESCRIPTION
This is PR 4 of 4 planned:

* [done] Manage Python deps via uv
* [done] Create a tools-only conda env responsible for MEGAHIT, BBTools, etc.
* [done] Standardize tool invocation from the pipeline: no conda run -n ... (meaningful runtime overhead); clarify docs about how to activate the conda env before running Python with uv.
* Add KMC to tools conda env, and cleanup docs indicating "non conda dependencies"

All of these will get merged into the dependency_rework branch, which then is merged into main.
