### PR TITLE
Return configs in forward orientation with respect to seed

### DIFF
--- a/outward_assembly/basic_seq_operations.py
+++ b/outward_assembly/basic_seq_operations.py
@@ -1,4 +1,7 @@
+from typing import Dict, List
+
 from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
 
 
 def is_subseq(needle: str | Seq, haystack: str | Seq, check_rc: bool = True) -> bool:
@@ -20,7 +23,30 @@ def is_subseq(needle: str | Seq, haystack: str | Seq, check_rc: bool = True) -> 
     if not check_rc:
         return needle_str in haystack_str
 
-    return (
-        needle_str in haystack_str
-        or str(Seq(needle_str).reverse_complement()) in haystack_str
-    )
+    return needle_str in haystack_str or str(Seq(needle_str).reverse_complement()) in haystack_str
+
+
+def contig_ids_by_seed(records: List[SeqRecord], seed_seqs: List[Seq]) -> Dict[int, bool]:
+    """
+    Given a list of SeqRecord contigs, that contain any of the seed sequences or their reverse
+    complements. Contigs are returned in forward orientation with respect to the seed.
+
+    Args:
+        records: List of SeqRecord objects representing contigs
+        seed_seqs: List of seed sequences to search for
+    Returns:
+        Dict whose keys correspond to the indices of records that contain seed sequences, and
+        whose values correspond to the contig orientation with respect to the seed (True
+        for forward orientation, False for reverse compliment)
+    """
+    filtered_records = {}
+    for i, rec in enumerate(records):
+        for seed in seed_seqs:
+            if is_subseq(needle=str(seed), haystack=str(rec.seq), check_rc=False):
+                filtered_records[i] = True
+            elif is_subseq(
+                needle=str(seed.reverse_complement()), haystack=str(rec.seq), check_rc=False
+            ):
+                filtered_records[i] = False
+
+    return filtered_records

--- a/outward_assembly/basic_seq_operations.py
+++ b/outward_assembly/basic_seq_operations.py
@@ -54,9 +54,10 @@ def contig_ids_by_seed(
     records: List[SeqRecord], seed_seqs: List[Seq]
 ) -> Dict[int, SeqOrientation]:
     """
-    Given a list of contigs and a list of seed sequences, returns the indices of contigs
-    that contain at least one seed, along with the orientation of the contig with respect
-    to the seed.
+    Given a list of contigs and a list of seed sequences, returns the indices of each contig
+    that contains at least one seed, along with its orientation with respect to the seed
+    (forward or reverse complement). (If a contig has multiple seeds, we return its
+    orientation with respect to the first seed in the contig.)
 
     Args:
         records: List of SeqRecord objects representing contigs

--- a/outward_assembly/basic_seq_operations.py
+++ b/outward_assembly/basic_seq_operations.py
@@ -1,7 +1,28 @@
+from enum import Enum
 from typing import Dict, List
 
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+
+
+class SeqOrientation(int, Enum):
+    """
+    Orientation of a sequence (forward or reverse compliment) relative to some reference
+    sequence.
+    """
+
+    FORWARD = 1
+    REVERSE = -1
+
+    def __mul__(self, other: "SeqOrientation | int") -> "SeqOrientation":
+        if not isinstance(other, SeqOrientation):
+            other = SeqOrientation(other)
+        return SeqOrientation(self.value * other.value)
+
+    def __rmul__(self, other: "SeqOrientation | int") -> "SeqOrientation":
+        if not isinstance(other, SeqOrientation):
+            other = SeqOrientation(other)
+        return SeqOrientation(self.value * other.value)
 
 
 def is_subseq(needle: str | Seq, haystack: str | Seq, check_rc: bool = True) -> bool:
@@ -23,30 +44,40 @@ def is_subseq(needle: str | Seq, haystack: str | Seq, check_rc: bool = True) -> 
     if not check_rc:
         return needle_str in haystack_str
 
-    return needle_str in haystack_str or str(Seq(needle_str).reverse_complement()) in haystack_str
+    return (
+        needle_str in haystack_str
+        or str(Seq(needle_str).reverse_complement()) in haystack_str
+    )
 
 
-def contig_ids_by_seed(records: List[SeqRecord], seed_seqs: List[Seq]) -> Dict[int, bool]:
+def contig_ids_by_seed(
+    records: List[SeqRecord], seed_seqs: List[Seq]
+) -> Dict[int, SeqOrientation]:
     """
-    Given a list of contigs and a list of seed sequences, returns the indices of contigs that 
-    contain at least one seed, along with the orientation of the contig with respect to the seed.
+    Given a list of contigs and a list of seed sequences, returns the indices of contigs
+    that contain at least one seed, along with the orientation of the contig with respect
+    to the seed.
 
     Args:
         records: List of SeqRecord objects representing contigs
         seed_seqs: List of seed sequences to search for
     Returns:
-        Dict whose keys correspond to the indices of records that contain seed sequences, and
-        whose values correspond to the contig orientation with respect to the seed (True
-        for forward orientation, False for reverse compliment)
+        Dict whose keys correspond to the indices of records that contain seed sequences,
+        and whose values correspond to the contig orientation with respect to the seed
     """
     filtered_records = {}
     for i, rec in enumerate(records):
+        contig_sequence = str(rec.seq)
         for seed in seed_seqs:
-            if is_subseq(needle=str(seed), haystack=str(rec.seq), check_rc=False):
-                filtered_records[i] = True
+            if is_subseq(needle=str(seed), haystack=contig_sequence, check_rc=False):
+                filtered_records[i] = SeqOrientation.FORWARD
+                break
             elif is_subseq(
-                needle=str(seed.reverse_complement()), haystack=str(rec.seq), check_rc=False
+                needle=str(seed.reverse_complement()),
+                haystack=contig_sequence,
+                check_rc=False,
             ):
-                filtered_records[i] = False
+                filtered_records[i] = SeqOrientation.REVERSE
+                break
 
     return filtered_records

--- a/outward_assembly/basic_seq_operations.py
+++ b/outward_assembly/basic_seq_operations.py
@@ -28,8 +28,8 @@ def is_subseq(needle: str | Seq, haystack: str | Seq, check_rc: bool = True) -> 
 
 def contig_ids_by_seed(records: List[SeqRecord], seed_seqs: List[Seq]) -> Dict[int, bool]:
     """
-    Given a list of SeqRecord contigs, that contain any of the seed sequences or their reverse
-    complements. Contigs are returned in forward orientation with respect to the seed.
+    Given a list of contigs and a list of seed sequences, returns the indices of contigs that 
+    contain at least one seed, along with the orientation of the contig with respect to the seed.
 
     Args:
         records: List of SeqRecord objects representing contigs

--- a/outward_assembly/overlap_graph.py
+++ b/outward_assembly/overlap_graph.py
@@ -127,9 +127,9 @@ def overlap_inds(
 
     Args:
         seqs: Sequences to analyze
-        subset_seqs: Dict whose keys are indices into above list corresponding to sequences that
-            have the seed sequence, and whose values are bools corresponding to whether the
-            sequence is in forward orientation (True) or reverse orientation (False)
+        subset_seqs: Dict to use to subset the above the sequences. The keys of this dict are
+            indices of seqs, corresponding to sequences that contain a seed. The values of the
+            dict are the orientation
         n_0_error: Minimum overlap length for exact match
         n_1_error: Minimum overlap length when allowing 1 mismatch
 
@@ -139,7 +139,7 @@ def overlap_inds(
     seqs = [Seq(s) if isinstance(s, str) else s for s in seqs]
 
     g = _overlap_graph(seqs, n_0_error, n_1_error)
-    components: List[set] = nx.connected_components(g)
+    components = nx.connected_components(g)
 
     # Find sequences containing seeds as substrings (is_subseq check)
     # Get the indices of all sequences that have a seed

--- a/outward_assembly/pipeline_steps.py
+++ b/outward_assembly/pipeline_steps.py
@@ -12,7 +12,7 @@ from Bio.SeqRecord import SeqRecord
 
 from .basic_seq_operations import SeqOrientation, contig_ids_by_seed
 from .io_helpers import PathLike, S3Files, concat_and_tag_fastq
-from .overlap_graph import overlap_inds
+from .overlap_graph import get_overlapping_sequence_ids
 
 # File names used across functions
 CURRENT_CONTIGS = "current_contigs.fasta"
@@ -125,7 +125,8 @@ def _subset_contigs(
         workdir: Working directory containing megahit output
         iter: Current iteration number
         seed_seqs: Seed sequences to search for
-        include_overlaps: Whether to include contigs in connected components
+        include_overlaps: Whether to include contigs that do not contain a seed themselves,
+            but are connected via overlapping sequences with a contig that does
         overlap_n0: Minimum overlap length for exact matches
         overlap_n1: Minimum overlap length when allowing 1 error
     """
@@ -155,7 +156,7 @@ def _subset_contigs(
 
         if include_overlaps:
             seqs = [rec.seq for rec in records]
-            subsetted_ids_and_orientations = overlap_inds(
+            subsetted_ids_and_orientations = get_overlapping_sequence_ids(
                 seqs, subsetted_ids_and_orientations, overlap_n0, overlap_n1
             )
 

--- a/tests/integration/test_pipeline_steps.py
+++ b/tests/integration/test_pipeline_steps.py
@@ -56,7 +56,7 @@ def overlapping_contig_reverse(temp_workdir_with_contigs):
     """
     megahit_dir = temp_workdir_with_contigs / "megahit_out_iter1-1"
     contigs_path = megahit_dir / "final.contigs.fa"
-    # Create an additional contig that overlaps with contig 5
+    # Create an additional contig that overlaps with RC of contig 5
     with open(contigs_path, "a") as f:
         f.write(">contig7\nCGTCTATATATATATAT\n")
 

--- a/tests/test_basic_seq_operations.py
+++ b/tests/test_basic_seq_operations.py
@@ -1,7 +1,12 @@
 import pytest
 from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
 
-from outward_assembly.basic_seq_operations import is_subseq
+from outward_assembly.basic_seq_operations import (
+    SeqOrientation,
+    contig_ids_by_seed,
+    is_subseq,
+)
 
 
 @pytest.mark.fast
@@ -49,3 +54,25 @@ def test_is_subseq_str_inputs():
     """Verify function works with string inputs as well as Seq objects"""
     assert is_subseq("AAGT", "CCACTTGG", check_rc=True)
     assert not is_subseq("AAGT", "CCACTTGG", check_rc=False)
+
+
+@pytest.mark.fast
+@pytest.mark.unit
+def test_contig_ids_by_seed():
+    """
+    Tests that contig_ids_by_seed returns the subset of contigs that contain seeds, along
+    with each contig's orientation with respect to the first seed in the contig
+    """
+    seed = Seq("AAAT")
+    contigs = [
+        SeqRecord(seq=Seq("AAATCGCGCGCG")),  # Seq0: contains seed in FWD orientation
+        SeqRecord(seq=Seq("ATTTGCGCGCGC")),  # Seq1: contains seed in RC orientation
+        SeqRecord(seq=Seq("CCCCCGGGGGG")),  # Seq2: does not contain seed
+        SeqRecord(seq=Seq("AAATATTTCCG")),  # Seq3: contains seed in FWD and then RC
+    ]
+    result = contig_ids_by_seed(records=contigs, seed_seqs=[seed])
+    assert result == {
+        0: SeqOrientation.FORWARD,
+        1: SeqOrientation.REVERSE,
+        3: SeqOrientation.FORWARD,
+    }

--- a/tests/test_overlap_graph.py
+++ b/tests/test_overlap_graph.py
@@ -2,7 +2,10 @@ import networkx
 import pytest
 
 from outward_assembly.basic_seq_operations import SeqOrientation
-from outward_assembly.overlap_graph import _traverse_subgraph_and_orient, overlap_inds
+from outward_assembly.overlap_graph import (
+    _traverse_subgraph_and_orient,
+    get_overlapping_sequence_ids,
+)
 
 
 @pytest.mark.fast
@@ -27,7 +30,9 @@ def test_overlap_inds_multiple_seeds():
     }
 
     # Test connected component behavior
-    result = overlap_inds(seqs, seq_ids_containing_seeds, n_0_error=5, n_1_error=7)
+    result = get_overlapping_sequence_ids(
+        seqs, seq_ids_containing_seeds, n_0_error=5, n_1_error=7
+    )
 
     # Should include sequences containing seeds and those connected to them
     assert sorted(result) == [0, 1, 2, 3, 4]
@@ -43,12 +48,12 @@ def test_traverse_subgraph_and_orient(initial_orientation):
     connected components and re-orients them all with respect to the initial node's
     orientation.
 
-    The initial graph looks like:
+    The overlap graph looks like this, and we will orient all nodes with respect to node 2:
     0 --fwd-- 1 --rev-- 2 --fwd-- 3     5
-                            |
-                            --rev-- 4
-    And we are trying to orient all nodes with respect to node 2.
+                        |
+                        --rev-- 4
     """
+    # Construct overlap graph
     g = networkx.Graph()
     g.add_nodes_from([0, 1, 2, 3, 4, 5])
     g.add_edge(0, 1, orientation=SeqOrientation.FORWARD)
@@ -56,7 +61,9 @@ def test_traverse_subgraph_and_orient(initial_orientation):
     g.add_edge(2, 3, orientation=SeqOrientation.FORWARD)
     g.add_edge(2, 4, orientation=SeqOrientation.REVERSE)
 
-    oriented_connected_components = _traverse_subgraph_and_orient(g, 2, initial_orientation)
+    oriented_connected_components = _traverse_subgraph_and_orient(
+        g, reference_seq_idx=2, reference_seq_orientation=initial_orientation
+    )
     expected_orientations = {
         0: SeqOrientation.REVERSE,
         1: SeqOrientation.REVERSE,

--- a/tests/test_overlap_graph.py
+++ b/tests/test_overlap_graph.py
@@ -39,6 +39,7 @@ def test_overlap_inds_multiple_seeds():
 
 
 @pytest.mark.fast
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "initial_orientation", (SeqOrientation.FORWARD, SeqOrientation.REVERSE)
 )

--- a/tests/test_overlap_graph.py
+++ b/tests/test_overlap_graph.py
@@ -1,8 +1,6 @@
 import pytest
-from Bio.Seq import Seq
 
-from outward_assembly.basic_seq_operations import is_subseq
-from outward_assembly.overlap_graph import overlap_inds, seqs_overlap
+from outward_assembly.overlap_graph import overlap_inds
 
 
 @pytest.mark.fast
@@ -21,13 +19,13 @@ def test_overlap_inds_multiple_seeds():
     ]
 
     # Define seeds
-    seed_seqs = [
-        Seq("TACGTA"),  # seed0: contained in seq0
-        Seq("GAAAACCC"),  # seed1: contained in seq3
-    ]
+    seq_ids_containing_seeds = {
+        0: True,  # seq0: forward direction
+        3: True,  # seq3: forward direction
+    }
 
     # Test connected component behavior
-    result = overlap_inds(seqs, seed_seqs, n_0_error=5, n_1_error=7)
+    result = overlap_inds(seqs, seq_ids_containing_seeds, n_0_error=5, n_1_error=7)
 
     # Should include sequences containing seeds and those connected to them
     assert sorted(result) == [0, 1, 2, 3, 4]


### PR DESCRIPTION
### Context

Addresses #1: keep contigs in the "forward seed" direction. After each iteration of assembly, when we return the subset contigs that contain our seed sequences of interest, those contigs should be returned in forward orientation with respect to the seed.

### Summary of changes

Based on @evanfields' impression that the double loop to iterate over every seed, for every contig, can be quite time-expensive, I opted to capture the seed orientation information in the existing loop that checks each contig for the presence of a seed. This means that I'm now passing around a dictionary associating contigs to orientations in order to RC them if needed later, which perhaps isn't the most readable. It seemed okay for now, especially if the contig seed search logic is going to be updated in #10 anyway, but I'm definitely open to other suggestions! 

Changes:
- Adds a new function, `contig_ids_by_seed`, that iterates over all specified contigs and checks each one for the presence of any of the specified seeds, and returns a dict mapping the contigs to whether they are in forward orientation for the seed. (This replaces the previous double list comprehension for filtering contigs for seeds).
- Updates the `overlap_inds` function to accept the output of the above function as an argument, so that it can annotate all connected components with their orientation too. This allows us to return connected components in the forward seed orientation as well.
- Adds unit tests for the above.




