### PR TITLE
Save overlap graph diagnostics for contig filtering

### DIFF
--- a/docs/algorithm_details.md
+++ b/docs/algorithm_details.md
@@ -32,6 +32,13 @@ So during the step "filter contigs to those that contain the seed," the full out
 
 Ideally, this modified filtering step retains all contigs that could be stitched together with a seed-containing contig while discarding irrelevant unrelated contigs.
 
+When overlap filtering is enabled, each MEGAHIT subiteration directory also includes
+`contig_overlap_graph.tsv`. This file records the retained overlap edges, whether each
+endpoint directly contained a seed, and each endpoint's orientation with respect to the
+seed. This is intended as a debugging aid: if a contig is retained only because it overlaps
+a seed-containing contig, the TSV shows the chain of evidence that caused the filter to
+keep it and the oriented contig IDs to inspect when stitching contigs manually.
+
 ## Assembly strictness and coverage thresholds
 Sequencing errors are common, and assemblers like MEGAHIT use coverage depth to decide when to apply error reduction procedures like tip pruning and bubble popping. Unfortunately, we're often assembling a sequence with very low coverage; maybe we've seen the seed just a handful of times -- if we've seen the seed a bunch and have deep coverage, we should have been trying to assemble one delivery ago.
 

--- a/docs/examining-work-dir.md
+++ b/docs/examining-work-dir.md
@@ -10,6 +10,7 @@ Each invocation of outward assembly creates a working directory which records th
 ├── megahit_out_iter<i>-<j> # iteration i, subiteration j
 │   ├── chose_this_subiter # empty file created if this subiter's contigs were chosen
 │   ├── contigs_filtered.fasta # final.contigs.fa filtered to contigs relating to our seeds
+│   ├── contig_overlap_graph.tsv # why overlap-filtered contigs were retained, if enabled
 │   ├── final.contigs.fa # megahit output of this subiter's assembly
 │   └── # other megahit outputs
 ├── original_seed.fasta
@@ -157,3 +158,27 @@ CCCCCCCCGCAGGCTGGATTCCCGTACGACATGGCTGTAGAGGTAGGCAAATGCAGCCCTTATCGTTCTGCGGCTGGGGC
 Notice:
 * Contig `k141_3` is the reverse complement of `k141_3` in `contigs_filtered.fasta`. When filtering contigs, we try to orient them in the forward-seed direction.
 * The `CCCCCCCCGCAGGCTGGATTCCCGTACGACATGGCTGTAG` "missing" from the end of our iteration 3 contig is found in MEGAHIT output contig `k141_4`! With the extra reads found in iteration 3, MEGAHIT's assembly took a different path through the `CCCCCCCCGCAGGCTGGATTCCCGTACGACATGGCTGTAG` assembly graph node than we had in iteration 2.
+
+## Why was a contig kept even though it does not contain a seed?
+
+If `overlap_contig_filtering=True`, each `megahit_out_iter<i>-<j>` directory contains a
+`contig_overlap_graph.tsv` file next to `contigs_filtered.fasta`. The file is a compact
+edge list for the retained portion of the contig overlap graph. For example:
+
+```
+source_contig	target_contig	source_oriented	target_oriented	edge_orientation	source_contains_seed	target_contains_seed
+contig5	contig6	contig5	contig6	forward	false	true
+contig7	contig5	contig7	rc:contig5	reverse	false	true
+```
+
+The `source_contig` and `target_contig` columns are the original MEGAHIT IDs. The
+`source_oriented` and `target_oriented` columns add an `rc:` prefix when that endpoint
+should be inspected as a reverse complement with respect to the seed. The
+`source_contains_seed` and `target_contains_seed` columns distinguish contigs retained
+because they directly contain a seed from contigs retained because they overlap a
+seed-containing component.
+
+This is especially helpful when `contigs_filtered.fasta` includes a contig that does not
+obviously contain your seed: look it up in `contig_overlap_graph.tsv`, then follow the
+edges until you reach a `*_contains_seed=true` endpoint. That path is the reason outward
+assembly kept the contig.

--- a/outward_assembly/overlap_graph.py
+++ b/outward_assembly/overlap_graph.py
@@ -1,11 +1,16 @@
 import warnings
 from collections import deque
-from typing import Dict, Sequence
+from typing import Dict, NamedTuple, Sequence
 
 import networkx as nx
 from Bio.Seq import Seq
 
 from outward_assembly.basic_seq_operations import SeqOrientation
+
+
+class OverlapGraphDiagnostics(NamedTuple):
+    graph: nx.Graph
+    connected_orientations: Dict[int, SeqOrientation]
 
 
 def _seqs_overlap_single(
@@ -185,17 +190,14 @@ def _traverse_subgraph_and_orient(
     return orientations
 
 
-def get_overlapping_sequence_ids(
+def get_overlap_graph_diagnostics(
     seqs: Sequence[str | Seq],
     seqs_containing_seed: Dict[int, SeqOrientation],
     n_0_error: int,
     n_1_error: int,
-) -> Dict[int, SeqOrientation]:
+) -> OverlapGraphDiagnostics:
     """
-    Get indices of sequences that are connected to any seed-containing sequence, where
-    connectedness is determined by the sequences having an overlapping region. Returns
-    0-based indices into the provided seqs list, along with the relative orientation of
-    each sequence with respect to the seed.
+    Build the overlap graph and find sequences connected to any seed-containing sequence.
 
     Args:
         seqs: Sequences to analyze
@@ -206,9 +208,10 @@ def get_overlapping_sequence_ids(
         n_1_error: Minimum overlap length when allowing 1 mismatch
 
     Returns:
-        Dict whose keys are the indices of any sequence that is connected via overlap to a
-        seed-containing sequence, and whose values are the relative orientation of the
-        sequence with respect to the seed
+        OverlapGraphDiagnostics containing the full overlap graph and a dict whose keys are
+        the indices of any sequence that is connected via overlap to a seed-containing
+        sequence, and whose values are the relative orientation of the sequence with
+        respect to the seed.
     """
     seqs = [Seq(s) if isinstance(s, str) else s for s in seqs]
 
@@ -234,4 +237,40 @@ def get_overlapping_sequence_ids(
         )
         all_connected_contigs.update(oriented_connected_contigs)
 
-    return all_connected_contigs
+    return OverlapGraphDiagnostics(
+        graph=g,
+        connected_orientations=all_connected_contigs,
+    )
+
+
+def get_overlapping_sequence_ids(
+    seqs: Sequence[str | Seq],
+    seqs_containing_seed: Dict[int, SeqOrientation],
+    n_0_error: int,
+    n_1_error: int,
+) -> Dict[int, SeqOrientation]:
+    """
+    Get indices of sequences that are connected to any seed-containing sequence, where
+    connectedness is determined by the sequences having an overlapping region. Returns
+    0-based indices into the provided seqs list, along with the relative orientation of
+    each sequence with respect to the seed.
+
+    Args:
+        seqs: Sequences to analyze
+        seqs_containing_seed: Dict to use to subset the above sequences. The keys of this
+            dict are indices of seqs, corresponding to sequences that contain a seed, and
+            the values are the orientation of each sequence relative to the seed it contains
+        n_0_error: Minimum overlap length for exact match
+        n_1_error: Minimum overlap length when allowing 1 mismatch
+
+    Returns:
+        Dict whose keys are the indices of any sequence that is connected via overlap to a
+        seed-containing sequence, and whose values are the relative orientation of the
+        sequence with respect to the seed
+    """
+    return get_overlap_graph_diagnostics(
+        seqs,
+        seqs_containing_seed,
+        n_0_error,
+        n_1_error,
+    ).connected_orientations

--- a/outward_assembly/pipeline_steps.py
+++ b/outward_assembly/pipeline_steps.py
@@ -13,7 +13,7 @@ from Bio.SeqRecord import SeqRecord
 
 from .basic_seq_operations import SeqOrientation
 from .io_helpers import PathLike, S3Files, concat_and_tag_fastq
-from .overlap_graph import get_overlapping_sequence_ids
+from .overlap_graph import get_overlap_graph_diagnostics
 
 # File names used across functions
 CURRENT_CONTIGS = "current_contigs.fasta"
@@ -32,6 +32,7 @@ READS_UNTRIMMED_2_FASTQ = "reads_untrimmed_2.fastq"
 MEGAHIT_OUT_PREFIX = "megahit_out_iter"
 MEGAHIT_FINAL_CONTIGS = "final.contigs.fa"
 MEGAHIT_FILTERED_CONTIGS = "contigs_filtered.fasta"
+MEGAHIT_OVERLAP_GRAPH = "contig_overlap_graph.tsv"
 CHOSEN_SUBITER_FLAG = "chose_this_subiter"
 LOG_FILE = "log.txt"
 
@@ -164,6 +165,70 @@ def _contig_ids_by_seed_ahocorasick(
     return matches
 
 
+def _format_oriented_contig_id(contig_id: str, orientation: SeqOrientation) -> str:
+    if orientation == SeqOrientation.REVERSE:
+        return f"rc:{contig_id}"
+    return contig_id
+
+
+def _write_contig_overlap_graph(
+    path: PathLike,
+    records: List[SeqRecord],
+    graph,
+    connected_orientations: Dict[int, SeqOrientation],
+    seed_contig_orientations: Dict[int, SeqOrientation],
+) -> None:
+    """Write a TSV explaining why overlap-filtered contigs were retained."""
+    path = Path(path)
+    selected_ids = set(connected_orientations)
+
+    with open(path, "w") as f:
+        f.write(
+            "\t".join(
+                [
+                    "source_contig",
+                    "target_contig",
+                    "source_oriented",
+                    "target_oriented",
+                    "edge_orientation",
+                    "source_contains_seed",
+                    "target_contains_seed",
+                ]
+            )
+            + "\n"
+        )
+
+        selected_edges = (
+            edge
+            for edge in graph.edges(data=True)
+            if edge[0] in selected_ids and edge[1] in selected_ids
+        )
+        for source_idx, target_idx, edge_data in sorted(
+            selected_edges, key=lambda edge: (records[edge[0]].id, records[edge[1]].id)
+        ):
+            source_orientation = connected_orientations[source_idx]
+            target_orientation = connected_orientations[target_idx]
+            edge_orientation = edge_data["orientation"]
+            f.write(
+                "\t".join(
+                    [
+                        records[source_idx].id,
+                        records[target_idx].id,
+                        _format_oriented_contig_id(
+                            records[source_idx].id, source_orientation
+                        ),
+                        _format_oriented_contig_id(
+                            records[target_idx].id, target_orientation
+                        ),
+                        edge_orientation.name.lower(),
+                        str(source_idx in seed_contig_orientations).lower(),
+                        str(target_idx in seed_contig_orientations).lower(),
+                    ]
+                )
+                + "\n"
+            )
+
+
 def _subset_contigs(
     workdir: PathLike,
     iter: int,
@@ -212,9 +277,17 @@ def _subset_contigs(
 
         if include_overlaps:
             seqs = [rec.seq for rec in records]
-            subsetted_ids_and_orientations = get_overlapping_sequence_ids(
+            overlap_diagnostics = get_overlap_graph_diagnostics(
                 seqs, subsetted_ids_and_orientations, overlap_n0, overlap_n1
             )
+            _write_contig_overlap_graph(
+                subiter_dir / MEGAHIT_OVERLAP_GRAPH,
+                records,
+                overlap_diagnostics.graph,
+                overlap_diagnostics.connected_orientations,
+                subsetted_ids_and_orientations,
+            )
+            subsetted_ids_and_orientations = overlap_diagnostics.connected_orientations
 
         for idx, orientation in subsetted_ids_and_orientations.items():
             record = records[idx]

--- a/tests/integration/test_pipeline_steps.py
+++ b/tests/integration/test_pipeline_steps.py
@@ -1,3 +1,4 @@
+import csv
 import tempfile
 from pathlib import Path
 
@@ -114,6 +115,22 @@ def test_subset_contigs_with_overlaps(temp_workdir_with_contigs, overlapping_con
     assert len(contig_ids) == 2
     assert "contig5" in contig_ids
 
+    graph_path = megahit_dir / "contig_overlap_graph.tsv"
+    with open(graph_path) as f:
+        overlap_edges = list(csv.DictReader(f, delimiter="\t"))
+
+    assert overlap_edges == [
+        {
+            "source_contig": "contig5",
+            "target_contig": "contig6",
+            "source_oriented": "contig5",
+            "target_oriented": "contig6",
+            "edge_orientation": "forward",
+            "source_contains_seed": "false",
+            "target_contains_seed": "true",
+        }
+    ]
+
 
 @pytest.mark.fast
 @pytest.mark.unit
@@ -144,6 +161,9 @@ def test_subset_contigs_preserves_seed_orientation(temp_workdir_with_contigs):
         "AAAAAAAAAAAAAAAAA",  # reverse complement of contig2
         "GGGGGGAAAAAACCCCCC",  # contig3
     } == contig_sequences
+
+    graph_path = workdir / "megahit_out_iter1-1" / "contig_overlap_graph.tsv"
+    assert not graph_path.exists()
 
 
 @pytest.mark.fast


### PR DESCRIPTION
## Summary
- add an `OverlapGraphDiagnostics` result so overlap filtering can reuse the graph it builds
- write `contig_overlap_graph.tsv` beside `contigs_filtered.fasta` whenever `include_overlaps=True`
- include original contig IDs, seed-oriented contig IDs (`rc:` prefix when appropriate), edge orientation, and whether each endpoint directly contained a seed
- add integration coverage for the emitted TSV and for not emitting it when overlap filtering is disabled
- document the artifact in the algorithm and working-directory debugging docs

Fixes #11.

## Why this matters
With overlap filtering enabled, outward assembly can retain contigs that do not directly contain a seed because they are connected to a seed-containing contig by overlap edges. Before this change, users could see those contigs in `contigs_filtered.fasta`, but not the evidence path explaining why they were retained or how to inspect their seed-relative orientation.

The new TSV is intentionally simple and operator-facing: it can be opened with shell tools/spreadsheets, followed as an edge list, and used to trace an overlap-only contig back to a `*_contains_seed=true` endpoint.

## Validation
- `uv run pytest tests/test_subset_contigs.py tests/test_overlap_graph.py tests/integration/test_pipeline_steps.py -q` — 13 passed
- `uv run ruff check outward_assembly/overlap_graph.py outward_assembly/pipeline_steps.py tests/integration/test_pipeline_steps.py tests/test_overlap_graph.py`
- `uv run black --check outward_assembly/overlap_graph.py outward_assembly/pipeline_steps.py tests/integration/test_pipeline_steps.py tests/test_overlap_graph.py`

I also ran `uv run pytest -q`; the local environment got to 71 passed / 1 skipped, then failed on existing external-tool/AWS integration paths because `bbduk.sh`, `nextflow`, and Batch env vars are not available locally. The failures were in `tests/integration/test_kmer_counting.py`, `tests/integration/test_pipeline.py`, and `tests/integration/test_subset_reads.py`, not in this patch's focused tests.
